### PR TITLE
STONEBLD-777 - tekton-ci: update bundle

### DIFF
--- a/.tekton/hacbs-jdk11-builder-pull-request.yaml
+++ b/.tekton/hacbs-jdk11-builder-pull-request.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk11-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk11-builder-push.yaml
+++ b/.tekton/hacbs-jdk11-builder-push.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk11-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk17-builder-pull-request.yaml
+++ b/.tekton/hacbs-jdk17-builder-pull-request.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk17-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk17-builder-push.yaml
+++ b/.tekton/hacbs-jdk17-builder-push.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk17-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk7-builder-pull-request.yaml
+++ b/.tekton/hacbs-jdk7-builder-pull-request.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk7-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk7-builder-push.yaml
+++ b/.tekton/hacbs-jdk7-builder-push.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk7-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk8-builder-pull-request.yaml
+++ b/.tekton/hacbs-jdk8-builder-pull-request.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk8-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:

--- a/.tekton/hacbs-jdk8-builder-push.yaml
+++ b/.tekton/hacbs-jdk8-builder-push.yaml
@@ -18,7 +18,7 @@ spec:
       value: hacbs-jdk8-builder/Dockerfile
   pipelineRef:
     name: docker-build
-    bundle: quay.io/redhat-appstudio/hacbs-core-service-templates-bundle:latest
+    bundle: quay.io/redhat-appstudio-tekton-catalog/pipeline-core-services-docker-build:latest
   workspaces:
     - name: workspace
       volumeClaimTemplate:


### PR DESCRIPTION
Switching to new bundle since development of old one was stopped before attempt to migrate to kcp. New bundle is removing dependency on shared secret.