### PR TITLE
Remove old GRADLE_OPTS

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -6,7 +6,6 @@ ENV \
     LC_ALL="en_US.UTF-8" \
     APP_HOME="/root" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
-    GRADLE_OPTS="-Dorg.gradle.daemon=false" \
     HOME="/root" \
     NSS_WRAPPER_PASSWD="/etc/passwd" \
     JAVA_HOME="/usr/lib/jvm/java-$JAVA_PACKAGE" \

--- a/jbs-ubi7-builder/Dockerfile
+++ b/jbs-ubi7-builder/Dockerfile
@@ -6,7 +6,6 @@ ENV \
     LC_ALL="en_US.UTF-8" \
     APP_HOME="/root" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
-    GRADLE_OPTS="-Dorg.gradle.daemon=false" \
     HOME="/root" \
     NSS_WRAPPER_PASSWD="/etc/passwd" \
     JAVA_HOME="/usr/lib/jvm/java-1.7.0" \

--- a/jbs-ubi8-builder/Dockerfile
+++ b/jbs-ubi8-builder/Dockerfile
@@ -6,7 +6,6 @@ ENV \
     LC_ALL="en_US.UTF-8" \
     APP_HOME="/root" \
     MAVEN_OPTS="-XX:+TieredCompilation -XX:TieredStopAtLevel=1" \
-    GRADLE_OPTS="-Dorg.gradle.daemon=false" \
     HOME="/root" \
     NSS_WRAPPER_PASSWD="/etc/passwd" \
     JAVA_HOME="/usr/lib/jvm/java-17" \


### PR DESCRIPTION
Changes in JBS mean we no longer explicitly disable the daemon as per Gradle recommendations (See https://github.com/redhat-appstudio/jvm-build-service/pull/1328 ) 