### PR TITLE
Add oras and build-trusted-artifact scripts

### DIFF
--- a/Dockerfile.template
+++ b/Dockerfile.template
@@ -32,6 +32,10 @@ RUN if [ "$UBI" = "8" ] ; then rpm --import https://www.centos.org/keys/RPM-GPG-
     && rpm -q java-latest-openjdk-devel ; \
     fi
 
+ADD https://github.com/oras-project/oras/releases/download/v${ORAS_VERSION}/oras_${ORAS_VERSION}_linux_amd64.tar.gz /tmp
+ADD https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/oras_opts.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/use-oci.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/select-oci-auth.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/create-oci.sh /usr/bin
+RUN tar -x -C /usr/bin -f /tmp/oras_${ORAS_VERSION}_linux_amd64.tar.gz && rm -f /usr/bin/LICENSE && chmod uog+x /usr/bin/oras_opts.sh /usr/bin/select-oci-auth.sh /usr/bin/create-oci.sh /usr/bin/use-oci.sh
+
 RUN set -o errexit -o nounset \
     # Using rm rather than microdnf clean to clear package manager metadata
     && rm -rf "/var/cache/yum" "/var/lib/rpm" "/var/lib/dnf" \

--- a/generate.sh
+++ b/generate.sh
@@ -58,7 +58,7 @@ generate () {
       export UBI_PKGS=$UBI8_PKGS
   fi
 
-  envsubst '$IMAGE_NAME,$MAVEN_VERSION,$MAVEN_SHA,$GRADLE_VERSION,$GRADLE_SHA,$GRADLE_MANIPULATOR_VERSION,$GRADLE_MANIPULATOR_HOME,$CLI_JAR_SHA,$ANALYZER_INIT_SHA,$TOOL_STRING,$JAVA_PACKAGE,$UBI,$UBI_PKGS,$UBI_IMAGE' < $DIR/Dockerfile.template > $DIR/$IMAGE_NAME/Dockerfile
+  envsubst '$IMAGE_NAME,$MAVEN_VERSION,$MAVEN_SHA,$GRADLE_VERSION,$GRADLE_SHA,$GRADLE_MANIPULATOR_VERSION,$GRADLE_MANIPULATOR_HOME,$CLI_JAR_SHA,$ANALYZER_INIT_SHA,$TOOL_STRING,$JAVA_PACKAGE,$ORAS_VERSION,$UBI,$UBI_PKGS,$UBI_IMAGE' < $DIR/Dockerfile.template > $DIR/$IMAGE_NAME/Dockerfile
   envsubst '$IMAGE_NAME' < $DIR/push.yaml > $DIR/.tekton/$IMAGE_NAME-push.yaml
   envsubst '$IMAGE_NAME' < $DIR/pull-request.yaml > $DIR/.tekton/$IMAGE_NAME-pull-request.yaml
   if [ "$UBI" == "7" ]; then
@@ -93,6 +93,8 @@ export SBT_1_8_0=fb52ea0bc0761176f3e38923ae5df556fba372895efb98a587f706d1ae80589
 
 export ANT_1_9_16=a815d3f323efa30db3451cc7c6d111ef343bbe2738e23161dbee1cbbeecf5b9a
 export ANT_1_10_13=800238184231f8002210fd0c75681bc20ce12f527c9b1dcb95fc8a33803bfce1
+
+export ORAS_VERSION=1.2.0
 
 export UBI8_PKGS="apr-devel autoconf automake bc buildah bzip2-devel cmake diffutils emacs-filesystem file findutils gcc gcc-c++ git glibc-devel glibc-devel.i686 glibc-langpack-en glibc-static golang gzip hostname iproute java-1.8.0-openjdk-devel java-11-openjdk-devel java-17-openjdk-devel java-21-openjdk-devel libcurl-devel libgcc.i686 libstdc++-static libtool lsof make openssl-devel perl-Digest-SHA podman shadow-utils tar tzdata-java unzip vim-filesystem wget which zip zlib-devel"
 export UBI7_PKGS="apr-devel autoconf automake bc diffutils file findutils gcc gcc-c++ git glibc-devel glibc-devel.i686 gzip iproute java-1.7.0-openjdk-devel java-1.8.0-openjdk-devel java-11-openjdk-devel libcurl-devel libgcc.i686 libtool lsof make openssl-devel perl-Digest-SHA shadow-utils tar unzip vim-filesystem wget which zip zlib-devel"

--- a/jbs-ubi7-builder/Dockerfile
+++ b/jbs-ubi7-builder/Dockerfile
@@ -32,6 +32,10 @@ RUN if [ "7" = "8" ] ; then rpm --import https://www.centos.org/keys/RPM-GPG-KEY
     && rpm -q java-latest-openjdk-devel ; \
     fi
 
+ADD https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz /tmp
+ADD https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/oras_opts.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/use-oci.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/select-oci-auth.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/create-oci.sh /usr/bin
+RUN tar -x -C /usr/bin -f /tmp/oras_1.2.0_linux_amd64.tar.gz && rm -f /usr/bin/LICENSE && chmod uog+x /usr/bin/oras_opts.sh /usr/bin/select-oci-auth.sh /usr/bin/create-oci.sh /usr/bin/use-oci.sh
+
 RUN set -o errexit -o nounset \
     # Using rm rather than microdnf clean to clear package manager metadata
     && rm -rf "/var/cache/yum" "/var/lib/rpm" "/var/lib/dnf" \

--- a/jbs-ubi8-builder/Dockerfile
+++ b/jbs-ubi8-builder/Dockerfile
@@ -32,6 +32,10 @@ RUN if [ "8" = "8" ] ; then rpm --import https://www.centos.org/keys/RPM-GPG-KEY
     && rpm -q java-latest-openjdk-devel ; \
     fi
 
+ADD https://github.com/oras-project/oras/releases/download/v1.2.0/oras_1.2.0_linux_amd64.tar.gz /tmp
+ADD https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/oras_opts.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/use-oci.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/select-oci-auth.sh https://raw.githubusercontent.com/konflux-ci/build-trusted-artifacts/main/create-oci.sh /usr/bin
+RUN tar -x -C /usr/bin -f /tmp/oras_1.2.0_linux_amd64.tar.gz && rm -f /usr/bin/LICENSE && chmod uog+x /usr/bin/oras_opts.sh /usr/bin/select-oci-auth.sh /usr/bin/create-oci.sh /usr/bin/use-oci.sh
+
 RUN set -o errexit -o nounset \
     # Using rm rather than microdnf clean to clear package manager metadata
     && rm -rf "/var/cache/yum" "/var/lib/rpm" "/var/lib/dnf" \


### PR DESCRIPTION
Thinking on this, tt might actually be better for JBS to have a direct reference to https://quay.io/repository/redhat-user-workloads/rhtap-build-tenant/trusted-artifacts/trusted-artifacts?tab=tags which means these changes could be dropped?